### PR TITLE
fix Nintendo Switch release dates

### DIFF
--- a/release/game.py
+++ b/release/game.py
@@ -25,12 +25,11 @@ class NSwitchGame(Game):
         self.title = title_col.get_text().strip()
 
     def parse_release_date(self, zones):
-        print(self.title)
-        dates = iter(self.row.find_all('td')[3:])
+        date = parse_date(
+            self.row.find_all('td')[3].get_text().strip(), fmt='%B %d, %Y'
+        )
         for zone in zones:
-            self.release_date[zone] = parse_date(
-                next(dates).get_text().strip(), fmt='%B %d, %Y'
-            )
+            self.release_date[zone] = date
 
 
 class PS4Game(Game):

--- a/release/platform.py
+++ b/release/platform.py
@@ -47,9 +47,10 @@ class NintendoSwitch(Platform):
     GAME_TYPE = NSwitchGame
     GAME_ZONES = ['JP', 'NA', 'PAL']
     WIKIPEDIA_PAGES = [
-        'List_of_Nintendo_Switch_games_(A–C)',
-        'List of Nintendo Switch games (D–F)',
-        'List of Nintendo Switch games (G–P)',
+        'List of Nintendo Switch games (0–9 and A)',
+        'List of Nintendo Switch games (B)',
+        'List of Nintendo Switch games (C–G)',
+        'List of Nintendo Switch games (H–P)',
         'List of Nintendo Switch games (Q–Z)'
     ]
 


### PR DESCRIPTION
The list of games on Wikipedia for the Nintendo Switch has been updated and so release date for different region are gone. Only one release date is available now.