### PR TITLE
Fix all day event for release date

### DIFF
--- a/release/utils.py
+++ b/release/utils.py
@@ -11,6 +11,6 @@ def to_kebab_case(name):
 
 def parse_date(date_string, fmt='%B %d, %Y'):
     try:
-        return datetime.strptime(date_string, fmt)
+        return datetime.strptime(date_string, fmt).date()
     except ValueError:
         return None


### PR DESCRIPTION
iCal require a DTEND if the DTSTART is a DATE-TIME so I use date instead of datetime for release date.